### PR TITLE
スポンサーとスタッフデータが足りないのでビルドが失敗しているのをコメントアウトする

### DIFF
--- a/source/index.html.slim
+++ b/source/index.html.slim
@@ -164,10 +164,10 @@ section.section
     /   .sponsors_list
     /     - data.sponsors.logos.each do |logos|
     /       = link_to image_tag(logos.logo_image_url), logos.url, class: 'sponsors_list_item-logos', target: '_blank', title: logos.name, 'data-toggle' => 'tooltip'
-    h3.sponsors_title DRINK SPONSORS
-    .sponsors_list
-      - data.sponsors.drinks.each do |drinks|
-        = link_to image_tag(drinks.logo_image_url), drinks.url, class: 'sponsors_list_item-drinks', target: '_blank', title: drinks.name, 'data-toggle' => 'tooltip'
+    /h3.sponsors_title DRINK SPONSORS
+    /.sponsors_list
+    /  - data.sponsors.drinks.each do |drinks|
+    /    = link_to image_tag(drinks.logo_image_url), drinks.url, class: 'sponsors_list_item-drinks', target: '_blank', title: drinks.name, 'data-toggle' => 'tooltip'
     / h3.sponsors_title MEDIA SPONSORS
     / .sponsors_list
     /   - data.sponsors.medias.each do |medias|
@@ -203,9 +203,9 @@ section.section
 section.section
   .container
     h2.section_title OFFICIAL COMMUNITIES
-    .sponsors_list
-      - data.sponsors.communities.each do |communities|
-        = link_to image_tag(communities.logo_image_url), communities.url, class: 'sponsors_list_item-drinks', target: '_blank', title: communities.name, 'data-toggle' => 'tooltip'
+    /.sponsors_list
+    /  - data.sponsors.communities.each do |communities|
+    /    = link_to image_tag(communities.logo_image_url), communities.url, class: 'sponsors_list_item-drinks', target: '_blank', title: communities.name, 'data-toggle' => 'tooltip'
 
 section.section.hidden-xs
   .container

--- a/source/staff/index.html.slim
+++ b/source/staff/index.html.slim
@@ -12,10 +12,10 @@ descriptipon: 運営スタッフ一覧と運営へのお問い合わせについ
     .staffList_list
       - data.staff.organizers.each do |organizer|
         = partial 'staff/human_card', locals: { human: organizer }
-    h2.staffList_title 事務局
-    .staffList_list
-      - data.staff.secretariat.each do |secretariat|
-        = partial 'staff/human_card', locals: { human: secretariat }
+/    h2.staffList_title 事務局
+/    .staffList_list
+/      - data.staff.secretariat.each do |secretariat|
+/        = partial 'staff/human_card', locals: { human: secretariat }
 
     h2.staffList_title お問い合わせ
     p プロダクトマネージャー・カンファレンス 運営事務局


### PR DESCRIPTION
sponsors.ymlとstaff.ymlに該当のデータがないため、手元でビルドが通りませんでした。

travis-ciでも同様のエラーがでているようなのでこれで直るかもしれません。