### PR TITLE
説明のところに(仮)が入っていたので削除

### DIFF
--- a/source/sessions/items/2018-10-07-session0704.html.md
+++ b/source/sessions/items/2018-10-07-session0704.html.md
@@ -1,10 +1,10 @@
 ---
 title: 気がついたらプロダクトマネージャーになっていた
-description: "（仮）気がついたらプロダクトマネージャーになっていた話。自身のNature Remoというプロダクトを通じての実体験について。"
+description: "気がついたらプロダクトマネージャーになっていた話。自身のNature Remoというプロダクトを通じての実体験について。"
 theme: "[07-04]"
 date: 2018-10-07 11:45
 author: "塩出 晴海"
 category: sessions
 og_image_url: https://2018.pmconf.jp/assets/images/speakers/nature_shiode.jpg
 ---
-（仮）気がついたらプロダクトマネージャーになっていた話。自身のNature Remoというプロダクトを通じての実体験について。
+気がついたらプロダクトマネージャーになっていた話。自身のNature Remoというプロダクトを通じての実体験について。


### PR DESCRIPTION
タイトルの通り。
文言が確定していない可能性もあるが、明日が本番なので `(仮)` が入っているよりは良いだろうと判断。